### PR TITLE
chore(deps): update AGP version to 9.1.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.1.0"
+agp = "9.1.1"
 coreKtx = "1.10.1"
 junit = "4.13.2"
 junitVersion = "1.1.5"


### PR DESCRIPTION
## Summary
- Update Android Gradle Plugin (AGP) version from 9.1.0 to 9.1.1

## Test plan
- [ ] Verify project builds successfully with the updated AGP version

🤖 Generated with [Claude Code](https://claude.com/claude-code)